### PR TITLE
Add rangemap indexer implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,8 @@ license = "MIT OR Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+rangemap = "0.4"
+ordered-float = "3"
 
 [dev-dependencies]
 test-case = "3.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,8 @@ license = "MIT OR Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rangemap = "0.4"
-ordered-float = "3"
+rangemap = "1.5"
+ordered-float = "5"
 
 [dev-dependencies]
 test-case = "3.0.0"

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -1,4 +1,5 @@
 pub mod algorithmic;
+pub mod rangemap;
 
 pub trait Indexer<T, S> {
     fn index(&self, v: T) -> S;

--- a/src/indexer/rangemap.rs
+++ b/src/indexer/rangemap.rs
@@ -1,0 +1,47 @@
+use crate::{BuildIndexer, Indexer};
+use ordered_float::OrderedFloat;
+use rangemap::RangeMap;
+
+#[derive(Default)]
+pub struct BuildRangemapIndexer;
+
+pub struct RangemapIndexer {
+    min: OrderedFloat<f64>,
+    max: OrderedFloat<f64>,
+    map: RangeMap<OrderedFloat<f64>, usize>,
+}
+
+impl Indexer<f64, usize> for RangemapIndexer {
+    fn index(&self, v: f64) -> usize {
+        let value = OrderedFloat(v).max(self.min).min(self.max);
+        *self.map.get(&value).expect("value not in range")
+    }
+}
+
+impl BuildIndexer<f64, usize> for BuildRangemapIndexer {
+    type Indexer = RangemapIndexer;
+
+    fn build_indexer<C>(&self, min: f64, max: f64, ticks: &[C]) -> Self::Indexer {
+        let step = (max - min) / (ticks.len() as f64 - 1.0);
+        let mut map = RangeMap::new();
+        let mut start = min;
+        for idx in 0..ticks.len() {
+            let end = if idx == ticks.len() - 1 {
+                max
+            } else {
+                min + step * (idx as f64 + 1.0)
+            };
+            if idx == ticks.len() - 1 {
+                map.insert(OrderedFloat(start)..=OrderedFloat(end), idx);
+            } else {
+                map.insert(OrderedFloat(start)..OrderedFloat(end), idx);
+            }
+            start = end;
+        }
+        RangemapIndexer {
+            min: OrderedFloat(min),
+            max: OrderedFloat(max),
+            map,
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 //! The sparklines crate provides a simple way to generate sparklines.
 
 use crate::indexer::algorithmic::BuildAlgorithmicIndexer;
+use crate::indexer::rangemap::BuildRangemapIndexer;
 use crate::indexer::{BuildIndexer, Indexer};
 
 mod indexer;
@@ -152,6 +153,12 @@ mod tests {
     #[test]
     fn test_default() {
         let spark = StringSpark::default();
+        assert_eq!(spark.spark(&[1.0, 2.0, 3.0]), "▁▅█");
+    }
+
+    #[test]
+    fn test_rangemap_indexer() {
+        let spark = StringSpark::<BuildRangemapIndexer>::new(&TICKS);
         assert_eq!(spark.spark(&[1.0, 2.0, 3.0]), "▁▅█");
     }
 


### PR DESCRIPTION
## Summary
- add BuildRangemapIndexer using rangemap and ordered-float
- wire new indexer module
- test new indexer

## Testing
- `cargo check` *(fails: failed to fetch ordered-float)*
- `cargo test` *(fails: failed to fetch ordered-float)*
- `cargo build` *(fails: failed to fetch ordered-float)*